### PR TITLE
Integrate Speckit workflow, add QA/perf/security skills, and enforce framework parity

### DIFF
--- a/ARQUITECTURA.md
+++ b/ARQUITECTURA.md
@@ -1,560 +1,102 @@
 # Arquitectura del Proyecto AC-Framework
 
-## Índice
-1. [Visión General](#visión-general)
-2. [Estructura de Carpetas Ocultas](#estructura-de-carpetas-ocultas)
-3. [Arquitectura OpenSpec](#arquitectura-openspec)
-4. [Las 10 Skills del Framework](#las-10-skills-del-framework)
-5. [Cómo Editar Skills de Forma Segura](#cómo-editar-skills-de-forma-segura)
-6. [Patrones de Comandos por Asistente](#patrones-de-comandos-por-asistente)
-7. [Flujo de Trabajo OpenSpec](#flujo-de-trabajo-openspec)
-
----
-
-## Visión General
-
-El **AC-Framework** (Agentic Coding Framework) es un sistema de configuración multi-asistente que proporciona flujos de trabajo consistentes de desarrollo asistido por IA en más de 20 asistentes de codificación diferentes.
-
-### Propósito Principal
-- Estandarizar el flujo de trabajo de desarrollo de software mediante la metodología "OpenSpec"
-- Implementar un **desarrollo basado en artefactos** donde los cambios progresan por fases estructuradas
-- Permitir que el mismo conjunto de skills, comandos y flujos de trabajo funcionen en diferentes asistentes de IA
-
-### Innovación Clave
-El framework mantiene **conjuntos de skills idénticos** en todos los asistentes, asegurando un comportamiento consistente independientemente de qué herramienta de IA use el desarrollador.
-
----
-
-## Estructura de Carpetas Ocultas
-
-El proyecto contiene **22 carpetas ocultas** organizadas por asistente/IDE, todas las carpetas se encuentran dentro de la carpeta framework (`.clinerules` se instala automáticamente junto con `.cline`):
-
-### Lista Completa de Carpetas
-
-| # | Carpeta | Asistente/Herramienta | Tipo | Estructura |
-|---|---------|----------------------|------|------------|
-| 1 | `.agent` | Generic Agent Framework | Agente | `skills/`, `workflows/` |
-| 2 | `.amazonq` | AWS Amazon Q | Cloud | `skills/`, `prompts/` |
-| 3 | `.augment` | Augment Code | Asistente | `skills/`, `commands/` |
-| 4 | `.claude` | Anthropic Claude Code | CLI | `skills/`, `commands/opsx/` |
-| 5 | `.cline` | Cline VS Code | Extensión | `skills/`, `workflows/` (incluye `.clinerules`) |
-| 6 | `.codebuddy` | CodeBuddy | Asistente | `skills/`, `commands/opsx/` |
-| 7 | `.codex` | OpenAI Codex | CLI | `skills/` |
-| 8 | `.continue` | Continue.dev | Extensión | `skills/`, `prompts/` |
-| 9 | `.cospec` | OpenSpec Nativo | Framework | `skills/`, `openspec/commands/` |
-| 10 | `.crush` | Crush | Asistente | `skills/`, `commands/opsx/` |
-| 11 | `.cursor` | Cursor IDE | IDE | `skills/`, `commands/` |
-| 12 | `.factory` | Factory | Asistente | `skills/`, `commands/` |
-| 13 | `.gemini` | Google Gemini | Cloud | `skills/`, `commands/opsx/` |
-| 14 | `.github` | GitHub Copilot | Extensión | `skills/`, `prompts/` |
-| 15 | `.iflow` | iFlow | Asistente | `skills/`, `commands/` |
-| 16 | `.kilocode` | Kilo Code | Asistente | `skills/`, `workflows/` |
-| 17 | `.opencode` | OpenCode | Framework | `skills/`, `command/` |
-| 18 | `.qoder` | Qoder | Asistente | `skills/`, `commands/opsx/` |
-| 19 | `.qwen` | Qwen (Alibaba) | Cloud | `skills/`, `commands/` |
-| 20 | `.roo` | Roo Code | Extensión | `skills/`, `commands/` |
-| 21 | `.trae` | Trae | IDE | `skills/` |
-| 22 | `.windsurf` | Windsurf | IDE | `skills/`, `workflows/` |
-
-### Tipos de Organización
-
-Las carpetas se organizan en tres patrones principales:
-
-#### 1. **Skills + Commands** (Mayoría)
-```
-.<asistente>/
-├── skills/openspec-{nombre}/SKILL.md    ← 10 skills idénticas
-└── commands/                             ← Comandos específicos
-    ├── opsx-new.md                       ← Formato plano
-    ├── opsx-apply.md
-    └── ...
-```
-
-**Asistentes con esta estructura:** `.augment`, `.cursor`, `.factory`, `.roo`, `.iflow`
-
-#### 2. **Skills + Commands Anidados**
-```
-.<asistente>/
-├── skills/openspec-{nombre}/SKILL.md
-└── commands/
-    └── opsx/                             ← Subdirectorio opsx
-        ├── new.md
-        ├── apply.md
-        └── ...
-```
-
-**Asistentes con esta estructura:** `.claude`, `.codebuddy`, `.crush`, `.qoder`
-
-#### 3. **Skills + Prompts**
-```
-.<asistente>/
-├── skills/openspec-{nombre}/SKILL.md
-└── prompts/
-    ├── opsx-new.prompt.md               ← GitHub Copilot
-    └── opsx-new.prompt                  ← Continue.dev
-```
-
-**Asistentes con esta estructura:** `.continue`, `.amazonq`, `.github`
-
-#### 4. **Skills + Workflows**
-```
-.<asistente>/
-├── skills/openspec-{nombre}/SKILL.md
-└── workflows/
-    ├── opsx-new.md
-    ├── opsx-apply.md
-    └── ...
-```
-
-**Asistentes con esta estructura:** `.agent`, `.kilocode`, `.windsurf`, `.clinerules` (incluido con `.cline`)
-
-#### 5. **Solo Skills**
-```
-.<asistente>/
-└── skills/openspec-{nombre}/SKILL.md
-```
-
-**Asistentes con esta estructura:** `.cline`, `.codex`, `.trae`
-
-#### 6. **Estructura Especial - OpenCode**
-```
-.opencode/
-├── .gitignore
-├── bun.lock
-├── package.json                         ← Tiene dependencias npm
-├── node_modules/                        ← Módulos instalados
-├── command/                             ← Nota: singular
-│   ├── opsx-new.md
-│   ├── opsx-apply.md
-│   └── ...
-└── skills/openspec-{nombre}/SKILL.md
-```
-
-**Nota:** `.opencode` es la implementación de referencia con dependencias reales.
-
----
-
-## Arquitectura OpenSpec
-
-### Conceptos Fundamentales
-
-OpenSpec implementa un **desarrollo basado en especificaciones abiertas** con los siguientes principios:
-
-1. **Todo cambio es un artefacto** - Los cambios se documentan antes de implementarse
-2. **Flujo estructurado** - Los cambios progresan por fases definidas
-3. **Separación de responsabilidades** - Especificación, diseño e implementación son distintos
-4. **Trazabilidad** - Todo está documentado y puede ser verificado
-
-### Jerarquía de Contenido
-
-```
-Single Source of Truth (Skills)
-            │
-            ├───────────────┐
-            ▼               ▼
-    SKILLS.md          Commands
-    (10 skills)        (10 comandos)
-    (lógica)           (interfaz)
-            │               │
-            └───────┬───────┘
-                    ▼
-        Format-Specific Outputs
-        (por asistente)
-```
-
-### Estructura de un Cambio OpenSpec
-
-Cada cambio se organiza así:
-
-```
-openspec/changes/{nombre-del-cambio}/
-├── proposal.md                        ← Por QUÉ hacer el cambio
-├── design.md                          ← CÓMO se implementará
-├── tasks.md                           ← Lista de tareas
-├── specs/
-│   └── {capability}/
-│       └── spec.md                    ← QUÉ cambia (ADDED/MODIFIED/REMOVED)
-└── archive/                           ← Cuando se completa
-```
-
----
-
-## Las 10 Skills del Framework
-
-Todas las carpetas contienen las **mismas 10 skills** con contenido idéntico:
-
-| # | Skill | Descripción | Comando |
-|---|-------|-------------|---------|
-| 1 | `openspec-onboard` | Tutorial guiado de bienvenida | `/opsx:onboard` |
-| 2 | `openspec-new-change` | Crear nuevo cambio (proposal, specs, design, tasks) | `/opsx:new` |
-| 3 | `openspec-continue-change` | Continuar cambio existente | `/opsx:continue` |
-| 4 | `openspec-ff-change` | Fast-forward: crear todos los artefactos rápidamente | `/opsx:ff` |
-| 5 | `openspec-apply-change` | Implementar tareas del cambio | `/opsx:apply` |
-| 6 | `openspec-verify-change` | Verificar implementación | `/opsx:verify` |
-| 7 | `openspec-archive-change` | Archivar cambio completado | `/opsx:archive` |
-| 8 | `openspec-bulk-archive-change` | Archivar múltiples cambios | `/opsx:bulk-archive` |
-| 9 | `openspec-sync-specs` | Sincronizar specs delta a specs principales | `/opsx:sync` |
-| 10 | `openspec-explore` | Modo exploración (pensar antes de actuar) | `/opsx:explore` |
-
-### Estructura de un SKILL.md
-
-Cada skill sigue este formato:
-
-```yaml
----
-name: openspec-{nombre}
-description: Descripción clara de cuándo usar esta skill
-license: MIT
-compatibility: Requires openspec CLI.
-metadata:
-  author: openspec
-  version: "1.0"
-  generatedBy: "1.1.1"
----
-
-# Título de la Skill
-
-## Steps
-
-1. **Nombre del Paso**
-   - Instrucciones detalladas
-   - Comandos bash: `openspec status --change "<nombre>" --json`
-   - Uso de herramientas: `**AskUserQuestion tool**`
-
-## Guardrails
-
-- Reglas de seguridad y restricciones
-- Qué NO hacer
-```
-
-### Metadatos Importantes
-
-- **`name`**: Identificador único de la skill
-- **`version`**: Versión de la skill
-- **`generatedBy`**: Versión del generador OpenSpec (ej: "1.1.1")
-- **`compatibility`**: Dependencias requeridas
-
----
-
-## Cómo Editar Skills de Forma Segura
-
-### REGLA DE ORO
-
-> **Siempre edita las 3-4 carpetas principales simultáneamente con cambios idénticos.**
-
-Las skills están **espejadas** en múltiples ubicaciones:
-- `.continue/skills/openspec-{nombre}/SKILL.md`
-- `.opencode/skills/openspec-{nombre}/SKILL.md`
-- `.github/skills/openspec-{nombre}/SKILL.md`
-- `.cospec/skills/openspec-{nombre}/SKILL.md`
-- Y en las otras 18+ carpetas de asistentes
-
-### Niveles de Impacto
-
-#### 🔴 Alto Impacto - Skills
-- **Ubicación**: Todas las carpetas `skills/`
-- **Impacto**: Afecta a TODOS los asistentes (22+)
-- **Sincronización requerida**: SÍ - todas las carpetas
-
-**Proceso seguro:**
-1. Edita UNA skill primero (ej: `.agent/skills/openspec-new-change/SKILL.md`)
-2. Prueba el cambio con ese asistente
-3. Si funciona, replica a TODAS las otras carpetas
-4. Todas las 22+ carpetas deben mantenerse sincronizadas
-
-#### 🟡 Medio Impacto - Comandos
-- **Ubicación**: Carpetas `commands/`, `command/`, `prompts/`
-- **Impacto**: Específico por asistente
-- **Sincronización requerida**: NO - formato específico
-
-**Proceso seguro:**
-1. Identifica el formato del asistente objetivo
-2. Edita en la ubicación apropiada:
-   - Plano: `.cursor/commands/opsx-new.md`
-   - Anidado: `.claude/commands/opsx/new.md`
-   - TOML: `.qwen/commands/opsx-new.toml`
-   - Prompt: `.continue/prompts/opsx-new.prompt`
-
-#### 🟢 Bajo Impacto - Workflows
-- **Ubicación**: Carpetas `workflows/`
-- **Impacto**: Específico por asistente (.agent, .kilocode, .windsurf, .clinerules incluido con .cline)
-- **Sincronización requerida**: NO
-
-### Checklist de Edición Segura
-
-#### Antes de Editar:
-- [ ] Identificar si es skill o comando
-- [ ] Identificar qué asistentes se verán afectados
-- [ ] Hacer backup del archivo original
-
-#### Al Editar Skills:
-- [ ] Preservar estructura YAML del frontmatter
-- [ ] Mantener patrón de numeración de pasos
-- [ ] Preservar referencias a herramientas (`AskUserQuestion tool`)
-- [ ] Mantener rutas: `openspec/changes/<nombre>/`
-- [ ] NO cambiar nombres de skills
-- [ ] NO modificar flujo de trabajo fundamental
-
-#### Al Editar Comandos:
-- [ ] Respetar el formato nativo del asistente
-- [ ] Mantener referencia a la skill correspondiente
-- [ ] Preservar nombre del comando (`opsx-*`)
-
-#### Después de Editar:
-- [ ] Probar con `.agent` (genérico, bien documentado)
-- [ ] Probar con `.claude` (estructura anidada)
-- [ ] Probar con `.cursor` (IDE popular)
-- [ ] Probar con `.opencode` (tiene dependencias npm)
-
-### Modificaciones Seguras vs Riesgosas
-
-#### ✅ Seguras:
-- Agregar/clarificar pasos
-- Agregar ejemplos
-- Agregar guardrails
-- Corregir typos
-- Expandir documentación
-
-#### ⚠️ Riesgosas (NO EJECUTAR AUTOMATICAMENTE):
-- Cambiar patrones de comandos CLI
-- Modificar estructura de rutas de archivos
-- Cambiar el flujo de trabajo
-- Alterar formatos de artefactos
-- Modificar versiones de metadatos
-
----
-
-## Patrones de Comandos por Asistente
-
-Cada asistente usa un formato diferente para los comandos:
-
-### 1. Markdown Plano con YAML Frontmatter
-
-**Asistentes:** `.augment`, `.cursor`, `.factory`, `.roo`, `.iflow`
-
-```markdown
----
-name: opsx-new
-description: Crear un nuevo cambio OpenSpec
----
-
-# /opsx:new
-
-Crea un nuevo cambio OpenSpec con proposal.md, specs/, design.md y tasks.md.
-
-## Uso
-
-/opsx:new <nombre-del-cambio>
-```
-
-### 2. Markdown Anidado en Subdirectorio
-
-**Asistentes:** `.claude`, `.codebuddy`, `.crush`, `.qoder`
-
-```
-.claude/commands/
-└── opsx/
-    ├── new.md
-    ├── apply.md
-    └── ...
-```
-
-### 3. TOML Format
-
-**Asistentes:** `.qwen`, `.gemini`
-
-```toml
-name = "opsx-new"
-description = "Crear un nuevo cambio OpenSpec"
-command = "/opsx:new"
-```
-
-### 4. Prompt Format (.prompt)
-
-**Asistentes:** `.continue`
-
-```
-.continue/prompts/
-├── opsx-new.prompt
-├── opsx-apply.prompt
-└── ...
-```
-
-Contenido similar al markdown pero extensión `.prompt`.
-
-### 5. Prompt Format (.prompt.md)
-
-**Asistentes:** `.github`
-
-```
-.github/prompts/
-├── opsx-new.prompt.md
-├── opsx-apply.prompt.md
-└── ...
-```
-
-### 6. Workflows Format
-
-**Asistentes:** `.agent`, `.kilocode`, `.windsurf`, `.clinerules` (incluido con `.cline`)
-
-```
-.agent/workflows/
-├── opsx-new.md
-├── opsx-apply.md
-└── ...
-```
-
-Contenido enfocado en flujo de trabajo de alto nivel.
-
----
-
-## Flujo de Trabajo OpenSpec
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                      EXPLORAR (/opsx:explore)               │
-│              Pensar, investigar, entender el problema       │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│     NUEVO (/opsx:new) o FAST-FORWARD (/opsx:ff)            │
-│  • proposal.md    ← Por qué                                │
-│  • specs/         ← Qué (ADDED/MODIFIED/REMOVED)          │
-│  • design.md      ← Cómo                                   │
-│  • tasks.md       ← Checklist de tareas                    │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    APLICAR (/opsx:apply)                    │
-│           Implementar cada tarea marcando - [x]             │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                   VERIFICAR (/opsx:verify)                  │
-│         Completitud, corrección, coherencia                │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼ (opcional)
-┌─────────────────────────────────────────────────────────────┐
-│                     SINCRONIZAR (/opsx:sync)                │
-│           Sincronizar specs delta a specs principales      │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                    ARCHIVAR (/opsx:archive)                 │
-│    Mover a openspec/changes/archive/YYYY-MM-DD-nombre/     │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Estados de un Cambio
-
-1. **DRAFT** - Cambio creado, en progreso
-2. **IN_PROGRESS** - Implementando tareas
-3. **VERIFYING** - En verificación
-4. **ARCHIVED** - Completado y archivado
-
-### Comandos CLI OpenSpec
-
-Las skills dependen de la CLI de OpenSpec:
-
+## 1) Resumen
+AC-Framework es un framework multi-asistente basado en OpenSpec. El núcleo vive en `framework/` y debe permanecer sincronizado entre todas las carpetas ocultas de asistentes.
+
+Principio operativo:
+- **Una sola arquitectura**
+- **Mismas skills transversales para todos los asistentes**
+- **Mismo workflow `ac.md` en todos los formatos (commands/prompts/workflows)**
+
+## 2) Módulos y fuente de verdad
+- Carpeta base: `framework/`
+- Carpeta de referencia para sincronización: `framework/.claude/`
+- Asistentes soportados con `skills/`: 22
+- Carpeta instalada automáticamente junto con `.cline`: `.clinerules`
+
+## 3) Taxonomía de skills (actualizada)
+
+### OpenSpec (núcleo)
+- openspec-onboard
+- openspec-explore
+- openspec-new-change
+- openspec-continue-change
+- openspec-ff-change
+- openspec-apply-change
+- openspec-verify-change
+- openspec-archive-change
+- openspec-bulk-archive-change
+- openspec-sync-specs
+
+### Calidad, seguridad y resiliencia
+- secure-coding-cybersecurity
+- code-maintainability
+- error-handling-patterns
+- systematic-debugging
+- security-scan
+- code-review
+
+### Planificación, análisis y diseño
+- brainstorming
+- project-index
+- api-design-principles
+- interface-design
+- speckit-clarify
+- speckit-specify
+- speckit-plan
+- performance-optimizer
+- test-planning
+- test-execution
+- sync-index
+
+### Documentación
+- changelog-generator
+- skill-writer
+
+## 4) Workflow obligatorio del comando `ac`
+El comando `ac` debe respetar fases con gates obligatorios:
+1. Preparación (`openspec-onboard`, constitución y memoria)
+2. Fundamentos (`speckit-clarify`, seguridad, mantenibilidad, errores, rendimiento)
+3. Exploración (`openspec-explore`, `project-index`)
+4. Especificación y plan (`speckit-specify`, `speckit-plan`, `openspec-*`, `test-planning`)
+5. Implementación (`openspec-apply-change`, `test-execution`, rendimiento)
+6. Validación (`systematic-debugging`, `openspec-verify-change`, `security-scan`, `code-review`)
+7. Cierre (`changelog-generator`, `sync-index`, `openspec-sync-specs`, `openspec-archive-change`)
+
+Artefactos mínimos:
+- `.agents/constitution.md`
+- `.agents/clarifications.md`
+- `.agents/project-index.md` (si proyecto existente)
+- `.agents/test-plan.md` y `.agents/test-results.md`
+- `.agents/security-scan.md`
+- `openspec/changes/<nombre>/{proposal.md,design.md,tasks.md,specs/...}`
+
+## 5) Sincronización segura de skills y comandos
+Regla estricta: cualquier cambio de skill o `ac.md` se replica a todas las carpetas equivalentes.
+
+Comprobación recomendada antes de publicar:
 ```bash
-# Estado del cambio
-openspec status --change "<nombre>" --json
-
-# Instrucciones de artefacto
-openspec instructions <artifacto> --change "<nombre>" --json
-
-# Listar cambios
-openspec list --json
-
-# Crear cambio
-openspec new change "<nombre>"
-
-# Archivar cambio
-openspec archive "<nombre>"
+acfm verify
 ```
 
----
+El verificador revisa:
+- conjunto de skills por asistente
+- hash de contenido de cada `SKILL.md`
+- paridad del archivo `ac.md` equivalente
 
-## Mejores Prácticas
+## 6) Guía de cambios
+### Alto impacto
+- `framework/.*/skills/**/SKILL.md`
+- `framework/.*/**/ac.md`
 
-### Para Contribuir al Framework:
+### Medio impacto
+- comandos `opsx-*` específicos de cada asistente
 
-1. **Siempre mantén sincronización** - Si cambias una skill, cámbiala en todas las carpetas
-2. **Prueba en múltiples asistentes** - No asumas que funciona en todos si funciona en uno
-3. **Documenta los cambios** - Añade comentarios en los PR sobre qué cambió y por qué
-4. **Respeta las versiones** - Si haces cambios significativos, considera actualizar la versión
-5. **Verifica compatibilidad** - Asegúrate de que los comandos CLI sigan funcionando
+### Bajo impacto
+- documentación y assets auxiliares
 
-### Para Uso Diario:
-
-1. **Empieza con /opsx:onboard** - Si eres nuevo, haz el tutorial primero
-2. **Usa /opsx:explore** - Antes de crear un cambio, explora el problema
-3. **Cambia incrementalmente** - No crees cambios gigantes, divídelos
-4. **Verifica antes de archivar** - Siempre ejecuta /opsx:verify
-5. **Mantén specs actualizados** - Usa /opsx:sync para mantener documentación
-
----
-
-## Referencia Rápida
-
-### Ubicaciones Clave:
-
-```
-/workspaces/AC-framework/
-├── README.md                          ← Este archivo
-├── ARQUITECTURA.md                    ← Documentación de arquitectura
-├── openspec/                          ← Configuración OpenSpec
-│   └── config.yaml
-├── openspec/changes/                  ← Cambios activos
-├── openspec/changes/archive/          ← Cambios archivados
-│
-├── .continue/skills/                  ← Skills para Continue.dev
-├── .opencode/skills/                  ← Skills para OpenCode
-├── .github/skills/                    ← Skills para GitHub Copilot
-├── .cursor/skills/                    ← Skills para Cursor
-│   └── ... (y 18+ carpetas más)
-│
-└── .opencode/command/                 ← Comandos OpenCode
-    ├── opsx-new.md
-    ├── opsx-apply.md
-    └── ...
-```
-
-### Comandos Útiles:
-
-```bash
-# Ver estructura de una carpeta
-tree -a .cursor/
-
-# Buscar skills específicas
-find . -path "*/skills/openspec-new-change/SKILL.md" -type f
-
-# Comparar skills entre asistentes
-diff .continue/skills/openspec-new-change/SKILL.md .opencode/skills/openspec-new-change/SKILL.md
-
-# Contar carpetas de asistentes
-ls -1d .[!.]* | wc -l
-```
-
----
-
-## Conclusión
-
-El AC-Framework es un sistema sofisticado que permite trabajar con múltiples asistentes de IA manteniendo consistencia en los flujos de trabajo. La clave para trabajar con él de forma segura es:
-
-1. **Entender la sincronización** - Las skills son compartidas por todos los asistentes
-2. **Respetar los formatos** - Cada asistente tiene su propio formato de comandos
-3. **Probar exhaustivamente** - Los cambios afectan a múltiples sistemas
-4. **Mantener la documentación** - El framework vive de la documentación clara
-
-Para cualquier modificación, sigue el principio: **"Cambia una vez, replica en todas partes."**
-
----
-
-*Documento generado para el proyecto AC-Framework*  
-*Última actualización: Febrero 2026*
+## 7) Convenciones
+- Nombres de skills: kebab-case
+- Archivos de skill: `skills/<skill-name>/SKILL.md`
+- Cambios OpenSpec: `openspec/changes/<change-name>/...`
+- Memoria operativa: `.agents/*.md`

--- a/README.md
+++ b/README.md
@@ -273,3 +273,28 @@ MIT © AC-Framework Team
   <strong>🚀 Desarrollo asistido por IA, estandarizado y potenciado</strong><br>
   <em>Trabaja con cualquier asistente, mantén el mismo flujo de trabajo</em>
 </p>
+
+## 🔍 Verificación de paridad
+
+Para evitar drift entre asistentes, ejecuta:
+
+```bash
+acfm verify
+```
+
+Opciones:
+
+```bash
+acfm verify --framework framework --reference .claude
+```
+
+Este comando valida que todas las carpetas tengan el mismo set de skills y que los `ac.md` equivalentes mantengan el mismo contenido.
+
+## 🧩 Nuevas skills de arquitectura
+
+Se añadieron skills para alinear OpenSpec con Speckit y reforzar calidad:
+- `speckit-clarify`, `speckit-specify`, `speckit-plan`
+- `test-planning`, `test-execution`
+- `performance-optimizer`
+- `security-scan`, `code-review`
+- `sync-index`

--- a/framework/.agent/skills/code-review/SKILL.md
+++ b/framework/.agent/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.agent/skills/performance-optimizer/SKILL.md
+++ b/framework/.agent/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.agent/skills/security-scan/SKILL.md
+++ b/framework/.agent/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.agent/skills/speckit-clarify/SKILL.md
+++ b/framework/.agent/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.agent/skills/speckit-plan/SKILL.md
+++ b/framework/.agent/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.agent/skills/speckit-specify/SKILL.md
+++ b/framework/.agent/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.agent/skills/sync-index/SKILL.md
+++ b/framework/.agent/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.agent/skills/test-execution/SKILL.md
+++ b/framework/.agent/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.agent/skills/test-planning/SKILL.md
+++ b/framework/.agent/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.agent/workflows/ac.md
+++ b/framework/.agent/workflows/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.amazonq/prompts/ac.md
+++ b/framework/.amazonq/prompts/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.amazonq/skills/code-review/SKILL.md
+++ b/framework/.amazonq/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.amazonq/skills/performance-optimizer/SKILL.md
+++ b/framework/.amazonq/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.amazonq/skills/security-scan/SKILL.md
+++ b/framework/.amazonq/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.amazonq/skills/speckit-clarify/SKILL.md
+++ b/framework/.amazonq/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.amazonq/skills/speckit-plan/SKILL.md
+++ b/framework/.amazonq/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.amazonq/skills/speckit-specify/SKILL.md
+++ b/framework/.amazonq/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.amazonq/skills/sync-index/SKILL.md
+++ b/framework/.amazonq/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.amazonq/skills/test-execution/SKILL.md
+++ b/framework/.amazonq/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.amazonq/skills/test-planning/SKILL.md
+++ b/framework/.amazonq/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.augment/commands/ac.md
+++ b/framework/.augment/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.augment/skills/code-review/SKILL.md
+++ b/framework/.augment/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.augment/skills/performance-optimizer/SKILL.md
+++ b/framework/.augment/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.augment/skills/security-scan/SKILL.md
+++ b/framework/.augment/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.augment/skills/speckit-clarify/SKILL.md
+++ b/framework/.augment/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.augment/skills/speckit-plan/SKILL.md
+++ b/framework/.augment/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.augment/skills/speckit-specify/SKILL.md
+++ b/framework/.augment/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.augment/skills/sync-index/SKILL.md
+++ b/framework/.augment/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.augment/skills/test-execution/SKILL.md
+++ b/framework/.augment/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.augment/skills/test-planning/SKILL.md
+++ b/framework/.augment/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.claude/commands/opsx/ac.md
+++ b/framework/.claude/commands/opsx/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.claude/skills/code-review/SKILL.md
+++ b/framework/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.claude/skills/performance-optimizer/SKILL.md
+++ b/framework/.claude/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.claude/skills/security-scan/SKILL.md
+++ b/framework/.claude/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.claude/skills/speckit-clarify/SKILL.md
+++ b/framework/.claude/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.claude/skills/speckit-plan/SKILL.md
+++ b/framework/.claude/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.claude/skills/speckit-specify/SKILL.md
+++ b/framework/.claude/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.claude/skills/sync-index/SKILL.md
+++ b/framework/.claude/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.claude/skills/test-execution/SKILL.md
+++ b/framework/.claude/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.claude/skills/test-planning/SKILL.md
+++ b/framework/.claude/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.cline/skills/code-review/SKILL.md
+++ b/framework/.cline/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.cline/skills/performance-optimizer/SKILL.md
+++ b/framework/.cline/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.cline/skills/security-scan/SKILL.md
+++ b/framework/.cline/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.cline/skills/speckit-clarify/SKILL.md
+++ b/framework/.cline/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.cline/skills/speckit-plan/SKILL.md
+++ b/framework/.cline/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.cline/skills/speckit-specify/SKILL.md
+++ b/framework/.cline/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.cline/skills/sync-index/SKILL.md
+++ b/framework/.cline/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.cline/skills/test-execution/SKILL.md
+++ b/framework/.cline/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.cline/skills/test-planning/SKILL.md
+++ b/framework/.cline/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.clinerules/workflows/ac.md
+++ b/framework/.clinerules/workflows/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.codebuddy/commands/opsx/ac.md
+++ b/framework/.codebuddy/commands/opsx/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.codebuddy/skills/code-review/SKILL.md
+++ b/framework/.codebuddy/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.codebuddy/skills/performance-optimizer/SKILL.md
+++ b/framework/.codebuddy/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.codebuddy/skills/security-scan/SKILL.md
+++ b/framework/.codebuddy/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.codebuddy/skills/speckit-clarify/SKILL.md
+++ b/framework/.codebuddy/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.codebuddy/skills/speckit-plan/SKILL.md
+++ b/framework/.codebuddy/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.codebuddy/skills/speckit-specify/SKILL.md
+++ b/framework/.codebuddy/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.codebuddy/skills/sync-index/SKILL.md
+++ b/framework/.codebuddy/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.codebuddy/skills/test-execution/SKILL.md
+++ b/framework/.codebuddy/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.codebuddy/skills/test-planning/SKILL.md
+++ b/framework/.codebuddy/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.codex/skills/code-review/SKILL.md
+++ b/framework/.codex/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.codex/skills/performance-optimizer/SKILL.md
+++ b/framework/.codex/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.codex/skills/security-scan/SKILL.md
+++ b/framework/.codex/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.codex/skills/speckit-clarify/SKILL.md
+++ b/framework/.codex/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.codex/skills/speckit-plan/SKILL.md
+++ b/framework/.codex/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.codex/skills/speckit-specify/SKILL.md
+++ b/framework/.codex/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.codex/skills/sync-index/SKILL.md
+++ b/framework/.codex/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.codex/skills/test-execution/SKILL.md
+++ b/framework/.codex/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.codex/skills/test-planning/SKILL.md
+++ b/framework/.codex/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.continue/prompts/ac.md
+++ b/framework/.continue/prompts/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.continue/skills/code-review/SKILL.md
+++ b/framework/.continue/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.continue/skills/performance-optimizer/SKILL.md
+++ b/framework/.continue/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.continue/skills/security-scan/SKILL.md
+++ b/framework/.continue/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.continue/skills/speckit-clarify/SKILL.md
+++ b/framework/.continue/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.continue/skills/speckit-plan/SKILL.md
+++ b/framework/.continue/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.continue/skills/speckit-specify/SKILL.md
+++ b/framework/.continue/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.continue/skills/sync-index/SKILL.md
+++ b/framework/.continue/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.continue/skills/test-execution/SKILL.md
+++ b/framework/.continue/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.continue/skills/test-planning/SKILL.md
+++ b/framework/.continue/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.cospec/openspec/commands/ac.md
+++ b/framework/.cospec/openspec/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.cospec/skills/code-review/SKILL.md
+++ b/framework/.cospec/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.cospec/skills/performance-optimizer/SKILL.md
+++ b/framework/.cospec/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.cospec/skills/security-scan/SKILL.md
+++ b/framework/.cospec/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.cospec/skills/speckit-clarify/SKILL.md
+++ b/framework/.cospec/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.cospec/skills/speckit-plan/SKILL.md
+++ b/framework/.cospec/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.cospec/skills/speckit-specify/SKILL.md
+++ b/framework/.cospec/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.cospec/skills/sync-index/SKILL.md
+++ b/framework/.cospec/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.cospec/skills/test-execution/SKILL.md
+++ b/framework/.cospec/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.cospec/skills/test-planning/SKILL.md
+++ b/framework/.cospec/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.crush/commands/opsx/ac.md
+++ b/framework/.crush/commands/opsx/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.crush/skills/code-review/SKILL.md
+++ b/framework/.crush/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.crush/skills/performance-optimizer/SKILL.md
+++ b/framework/.crush/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.crush/skills/security-scan/SKILL.md
+++ b/framework/.crush/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.crush/skills/speckit-clarify/SKILL.md
+++ b/framework/.crush/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.crush/skills/speckit-plan/SKILL.md
+++ b/framework/.crush/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.crush/skills/speckit-specify/SKILL.md
+++ b/framework/.crush/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.crush/skills/sync-index/SKILL.md
+++ b/framework/.crush/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.crush/skills/test-execution/SKILL.md
+++ b/framework/.crush/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.crush/skills/test-planning/SKILL.md
+++ b/framework/.crush/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.cursor/commands/ac.md
+++ b/framework/.cursor/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.cursor/skills/code-review/SKILL.md
+++ b/framework/.cursor/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.cursor/skills/performance-optimizer/SKILL.md
+++ b/framework/.cursor/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.cursor/skills/security-scan/SKILL.md
+++ b/framework/.cursor/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.cursor/skills/speckit-clarify/SKILL.md
+++ b/framework/.cursor/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.cursor/skills/speckit-plan/SKILL.md
+++ b/framework/.cursor/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.cursor/skills/speckit-specify/SKILL.md
+++ b/framework/.cursor/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.cursor/skills/sync-index/SKILL.md
+++ b/framework/.cursor/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.cursor/skills/test-execution/SKILL.md
+++ b/framework/.cursor/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.cursor/skills/test-planning/SKILL.md
+++ b/framework/.cursor/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.factory/commands/ac.md
+++ b/framework/.factory/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.factory/skills/code-review/SKILL.md
+++ b/framework/.factory/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.factory/skills/performance-optimizer/SKILL.md
+++ b/framework/.factory/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.factory/skills/security-scan/SKILL.md
+++ b/framework/.factory/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.factory/skills/speckit-clarify/SKILL.md
+++ b/framework/.factory/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.factory/skills/speckit-plan/SKILL.md
+++ b/framework/.factory/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.factory/skills/speckit-specify/SKILL.md
+++ b/framework/.factory/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.factory/skills/sync-index/SKILL.md
+++ b/framework/.factory/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.factory/skills/test-execution/SKILL.md
+++ b/framework/.factory/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.factory/skills/test-planning/SKILL.md
+++ b/framework/.factory/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.gemini/commands/opsx/ac.md
+++ b/framework/.gemini/commands/opsx/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.gemini/skills/code-review/SKILL.md
+++ b/framework/.gemini/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.gemini/skills/performance-optimizer/SKILL.md
+++ b/framework/.gemini/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.gemini/skills/security-scan/SKILL.md
+++ b/framework/.gemini/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.gemini/skills/speckit-clarify/SKILL.md
+++ b/framework/.gemini/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.gemini/skills/speckit-plan/SKILL.md
+++ b/framework/.gemini/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.gemini/skills/speckit-specify/SKILL.md
+++ b/framework/.gemini/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.gemini/skills/sync-index/SKILL.md
+++ b/framework/.gemini/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.gemini/skills/test-execution/SKILL.md
+++ b/framework/.gemini/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.gemini/skills/test-planning/SKILL.md
+++ b/framework/.gemini/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.github/prompts/ac.md
+++ b/framework/.github/prompts/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.github/skills/code-review/SKILL.md
+++ b/framework/.github/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.github/skills/performance-optimizer/SKILL.md
+++ b/framework/.github/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.github/skills/security-scan/SKILL.md
+++ b/framework/.github/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.github/skills/speckit-clarify/SKILL.md
+++ b/framework/.github/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.github/skills/speckit-plan/SKILL.md
+++ b/framework/.github/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.github/skills/speckit-specify/SKILL.md
+++ b/framework/.github/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.github/skills/sync-index/SKILL.md
+++ b/framework/.github/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.github/skills/test-execution/SKILL.md
+++ b/framework/.github/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.github/skills/test-planning/SKILL.md
+++ b/framework/.github/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.iflow/commands/ac.md
+++ b/framework/.iflow/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.iflow/skills/code-review/SKILL.md
+++ b/framework/.iflow/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.iflow/skills/performance-optimizer/SKILL.md
+++ b/framework/.iflow/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.iflow/skills/security-scan/SKILL.md
+++ b/framework/.iflow/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.iflow/skills/speckit-clarify/SKILL.md
+++ b/framework/.iflow/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.iflow/skills/speckit-plan/SKILL.md
+++ b/framework/.iflow/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.iflow/skills/speckit-specify/SKILL.md
+++ b/framework/.iflow/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.iflow/skills/sync-index/SKILL.md
+++ b/framework/.iflow/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.iflow/skills/test-execution/SKILL.md
+++ b/framework/.iflow/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.iflow/skills/test-planning/SKILL.md
+++ b/framework/.iflow/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.kilocode/skills/code-review/SKILL.md
+++ b/framework/.kilocode/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.kilocode/skills/performance-optimizer/SKILL.md
+++ b/framework/.kilocode/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.kilocode/skills/security-scan/SKILL.md
+++ b/framework/.kilocode/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.kilocode/skills/speckit-clarify/SKILL.md
+++ b/framework/.kilocode/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.kilocode/skills/speckit-plan/SKILL.md
+++ b/framework/.kilocode/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.kilocode/skills/speckit-specify/SKILL.md
+++ b/framework/.kilocode/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.kilocode/skills/sync-index/SKILL.md
+++ b/framework/.kilocode/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.kilocode/skills/test-execution/SKILL.md
+++ b/framework/.kilocode/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.kilocode/skills/test-planning/SKILL.md
+++ b/framework/.kilocode/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.kilocode/workflows/ac.md
+++ b/framework/.kilocode/workflows/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.opencode/command/ac.md
+++ b/framework/.opencode/command/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.opencode/skills/code-review/SKILL.md
+++ b/framework/.opencode/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.opencode/skills/openspec-apply-change/SKILL.md
+++ b/framework/.opencode/skills/openspec-apply-change/SKILL.md
@@ -22,7 +22,7 @@ Implement tasks from an OpenSpec change.
    - Auto-select if only one active change exists
    - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
 
-   Always announce: "Using change: <name>" and how to override (e.g., `/opsx-apply <other>`).
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
 
 2. **Check status to understand the schema**
    ```bash

--- a/framework/.opencode/skills/openspec-archive-change/SKILL.md
+++ b/framework/.opencode/skills/openspec-archive-change/SKILL.md
@@ -63,7 +63,7 @@ Archive a completed change in the experimental workflow.
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, execute /opsx-sync logic (use the openspec-sync-specs skill). Proceed to archive regardless of choice.
+   If user chooses sync, execute /opsx:sync logic (use the openspec-sync-specs skill). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 

--- a/framework/.opencode/skills/openspec-bulk-archive-change/SKILL.md
+++ b/framework/.opencode/skills/openspec-bulk-archive-change/SKILL.md
@@ -229,7 +229,7 @@ Failed K changes:
 ```
 ## No Changes to Archive
 
-No active changes found. Use `/opsx-new` to create a new change.
+No active changes found. Use `/opsx:new` to create a new change.
 ```
 
 **Guardrails**

--- a/framework/.opencode/skills/openspec-explore/SKILL.md
+++ b/framework/.opencode/skills/openspec-explore/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
-**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx-new` or `/opsx-ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first (e.g., start a change with `/opsx:new` or `/opsx:ff`). You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
 
 **This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
 
@@ -96,7 +96,7 @@ This tells you:
 Think freely. When insights crystallize, you might offer:
 
 - "This feels solid enough to start a change. Want me to create one?"
-  → Can transition to `/opsx-new` or `/opsx-ff`
+  → Can transition to `/opsx:new` or `/opsx:ff`
 - Or keep exploring - no pressure to formalize
 
 ### When a change exists
@@ -202,7 +202,7 @@ You: [reads codebase]
 
 **User is stuck mid-implementation:**
 ```
-User: /opsx-explore add-auth-system
+User: /opsx:explore add-auth-system
       The OAuth integration is more complex than expected
 
 You: [reads change artifacts]
@@ -252,7 +252,7 @@ You: That changes everything.
 
 There's no required ending. Discovery might:
 
-- **Flow into action**: "Ready to start? /opsx-new or /opsx-ff"
+- **Flow into action**: "Ready to start? /opsx:new or /opsx:ff"
 - **Result in artifact updates**: "Updated design.md with these decisions"
 - **Just provide clarity**: User has what they need, moves on
 - **Continue later**: "We can pick this up anytime"
@@ -269,8 +269,8 @@ When it feels like things are crystallizing, you might summarize:
 **Open questions**: [if any remain]
 
 **Next steps** (if ready):
-- Create a change: /opsx-new <name>
-- Fast-forward to tasks: /opsx-ff <name>
+- Create a change: /opsx:new <name>
+- Fast-forward to tasks: /opsx:ff <name>
 - Keep exploring: just keep talking
 ```
 

--- a/framework/.opencode/skills/openspec-ff-change/SKILL.md
+++ b/framework/.opencode/skills/openspec-ff-change/SKILL.md
@@ -81,7 +81,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions
 - What's ready: "All artifacts created! Ready for implementation."
-- Prompt: "Run `/opsx-apply` or ask me to implement to start working on the tasks."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
 
 **Artifact Creation Guidelines**
 

--- a/framework/.opencode/skills/openspec-onboard/SKILL.md
+++ b/framework/.opencode/skills/openspec-onboard/SKILL.md
@@ -22,7 +22,7 @@ openspec status --json 2>&1 || echo "NOT_INITIALIZED"
 ```
 
 **If not initialized:**
-> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx-onboard`.
+> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
 
 Stop here if not initialized.
 
@@ -146,7 +146,7 @@ Spend 1-2 minutes investigating the relevant code:
 │   [Optional: ASCII diagram if helpful]  │
 └─────────────────────────────────────────┘
 
-Explore mode (`/opsx-explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
 
 Now let's create a change to hold our work.
 ```
@@ -459,19 +459,19 @@ This same rhythm works for any size change—a small fix or a major feature.
 
 | Command | What it does |
 |---------|--------------|
-| `/opsx-explore` | Think through problems before/during work |
-| `/opsx-new` | Start a new change, step through artifacts |
-| `/opsx-ff` | Fast-forward: create all artifacts at once |
-| `/opsx-continue` | Continue working on an existing change |
-| `/opsx-apply` | Implement tasks from a change |
-| `/opsx-verify` | Verify implementation matches artifacts |
-| `/opsx-archive` | Archive a completed change |
+| `/opsx:explore` | Think through problems before/during work |
+| `/opsx:new` | Start a new change, step through artifacts |
+| `/opsx:ff` | Fast-forward: create all artifacts at once |
+| `/opsx:continue` | Continue working on an existing change |
+| `/opsx:apply` | Implement tasks from a change |
+| `/opsx:verify` | Verify implementation matches artifacts |
+| `/opsx:archive` | Archive a completed change |
 
 ---
 
 ## What's Next?
 
-Try `/opsx-new` or `/opsx-ff` on something you actually want to build. You've got the rhythm now!
+Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
 ```
 
 ---
@@ -486,8 +486,8 @@ If the user says they need to stop, want to pause, or seem disengaged:
 No problem! Your change is saved at `openspec/changes/<name>/`.
 
 To pick up where we left off later:
-- `/opsx-continue <name>` - Resume artifact creation
-- `/opsx-apply <name>` - Jump to implementation (if tasks exist)
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
 
 The work won't be lost. Come back whenever you're ready.
 ```
@@ -503,15 +503,15 @@ If the user says they just want to see the commands or skip the tutorial:
 
 | Command | What it does |
 |---------|--------------|
-| `/opsx-explore` | Think through problems (no code changes) |
-| `/opsx-new <name>` | Start a new change, step by step |
-| `/opsx-ff <name>` | Fast-forward: all artifacts at once |
-| `/opsx-continue <name>` | Continue an existing change |
-| `/opsx-apply <name>` | Implement tasks |
-| `/opsx-verify <name>` | Verify implementation |
-| `/opsx-archive <name>` | Archive when done |
+| `/opsx:explore` | Think through problems (no code changes) |
+| `/opsx:new <name>` | Start a new change, step by step |
+| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
+| `/opsx:continue <name>` | Continue an existing change |
+| `/opsx:apply <name>` | Implement tasks |
+| `/opsx:verify <name>` | Verify implementation |
+| `/opsx:archive <name>` | Archive when done |
 
-Try `/opsx-new` to start your first change, or `/opsx-ff` if you want to move fast.
+Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
 ```
 
 Exit gracefully.

--- a/framework/.opencode/skills/performance-optimizer/SKILL.md
+++ b/framework/.opencode/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.opencode/skills/security-scan/SKILL.md
+++ b/framework/.opencode/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.opencode/skills/speckit-clarify/SKILL.md
+++ b/framework/.opencode/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.opencode/skills/speckit-plan/SKILL.md
+++ b/framework/.opencode/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.opencode/skills/speckit-specify/SKILL.md
+++ b/framework/.opencode/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.opencode/skills/sync-index/SKILL.md
+++ b/framework/.opencode/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.opencode/skills/test-execution/SKILL.md
+++ b/framework/.opencode/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.opencode/skills/test-planning/SKILL.md
+++ b/framework/.opencode/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.qoder/commands/opsx/ac.md
+++ b/framework/.qoder/commands/opsx/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.qoder/skills/code-review/SKILL.md
+++ b/framework/.qoder/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.qoder/skills/performance-optimizer/SKILL.md
+++ b/framework/.qoder/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.qoder/skills/security-scan/SKILL.md
+++ b/framework/.qoder/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.qoder/skills/speckit-clarify/SKILL.md
+++ b/framework/.qoder/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.qoder/skills/speckit-plan/SKILL.md
+++ b/framework/.qoder/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.qoder/skills/speckit-specify/SKILL.md
+++ b/framework/.qoder/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.qoder/skills/sync-index/SKILL.md
+++ b/framework/.qoder/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.qoder/skills/test-execution/SKILL.md
+++ b/framework/.qoder/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.qoder/skills/test-planning/SKILL.md
+++ b/framework/.qoder/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.qwen/commands/ac.md
+++ b/framework/.qwen/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.qwen/skills/code-review/SKILL.md
+++ b/framework/.qwen/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.qwen/skills/performance-optimizer/SKILL.md
+++ b/framework/.qwen/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.qwen/skills/security-scan/SKILL.md
+++ b/framework/.qwen/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.qwen/skills/speckit-clarify/SKILL.md
+++ b/framework/.qwen/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.qwen/skills/speckit-plan/SKILL.md
+++ b/framework/.qwen/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.qwen/skills/speckit-specify/SKILL.md
+++ b/framework/.qwen/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.qwen/skills/sync-index/SKILL.md
+++ b/framework/.qwen/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.qwen/skills/test-execution/SKILL.md
+++ b/framework/.qwen/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.qwen/skills/test-planning/SKILL.md
+++ b/framework/.qwen/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.roo/commands/ac.md
+++ b/framework/.roo/commands/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/.roo/skills/code-review/SKILL.md
+++ b/framework/.roo/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.roo/skills/performance-optimizer/SKILL.md
+++ b/framework/.roo/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.roo/skills/security-scan/SKILL.md
+++ b/framework/.roo/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.roo/skills/speckit-clarify/SKILL.md
+++ b/framework/.roo/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.roo/skills/speckit-plan/SKILL.md
+++ b/framework/.roo/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.roo/skills/speckit-specify/SKILL.md
+++ b/framework/.roo/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.roo/skills/sync-index/SKILL.md
+++ b/framework/.roo/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.roo/skills/test-execution/SKILL.md
+++ b/framework/.roo/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.roo/skills/test-planning/SKILL.md
+++ b/framework/.roo/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.trae/skills/code-review/SKILL.md
+++ b/framework/.trae/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.trae/skills/performance-optimizer/SKILL.md
+++ b/framework/.trae/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.trae/skills/security-scan/SKILL.md
+++ b/framework/.trae/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.trae/skills/speckit-clarify/SKILL.md
+++ b/framework/.trae/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.trae/skills/speckit-plan/SKILL.md
+++ b/framework/.trae/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.trae/skills/speckit-specify/SKILL.md
+++ b/framework/.trae/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.trae/skills/sync-index/SKILL.md
+++ b/framework/.trae/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.trae/skills/test-execution/SKILL.md
+++ b/framework/.trae/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.trae/skills/test-planning/SKILL.md
+++ b/framework/.trae/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.windsurf/skills/code-review/SKILL.md
+++ b/framework/.windsurf/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Perform structured review against specs, maintainability rules, and security/performance constraints.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Code Review
+
+Cross-check implementation quality before archiving.
+
+## Steps
+1. Review diffs against `proposal.md`, `spec.md`, `design.md`, and `tasks.md`.
+2. Validate maintainability, naming, modularity, and error handling.
+3. Validate security and performance implications.
+4. Record blocking/non-blocking comments in `.agents/code-review.md`.
+5. Gate merge until blocking issues are resolved.
+
+## Output
+- `.agents/code-review.md`
+
+## Guardrails
+- Review must be evidence-based, not preference-only.

--- a/framework/.windsurf/skills/performance-optimizer/SKILL.md
+++ b/framework/.windsurf/skills/performance-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: performance-optimizer
+description: Define and validate performance goals, measure bottlenecks, and apply iterative optimizations.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Performance Optimizer
+
+Use in foundations, implementation, and verification phases.
+
+## Steps
+1. Define SLO/SLA targets (latency, throughput, resource usage) in `.agents/performance-budget.md`.
+2. Establish baseline metrics.
+3. Identify hotspots and propose optimizations.
+4. Re-measure and compare before/after.
+5. Record final findings in `.agents/performance-report.md`.
+
+## Output
+- `.agents/performance-budget.md`
+- `.agents/performance-report.md`
+
+## Guardrails
+- Prioritize measurable impact over speculative micro-optimizations.

--- a/framework/.windsurf/skills/security-scan/SKILL.md
+++ b/framework/.windsurf/skills/security-scan/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: security-scan
+description: Run automated security checks and summarize findings with remediation priorities.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Security Scan
+
+Automates vulnerability checks during validation.
+
+## Steps
+1. Select stack-appropriate scanners (e.g., npm audit, pip-audit, bandit, semgrep).
+2. Execute scans and collect outputs.
+3. Classify findings by severity and exploitability.
+4. Create remediation plan with owners/status.
+5. Save report to `.agents/security-scan.md`.
+
+## Output
+- `.agents/security-scan.md`
+
+## Guardrails
+- Do not suppress findings silently.
+- Document accepted risk with justification and expiry date.

--- a/framework/.windsurf/skills/speckit-clarify/SKILL.md
+++ b/framework/.windsurf/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: speckit-clarify
+description: Clarify ambiguous requirements before specification by asking up to five high-impact questions and recording decisions in .agents/clarifications.md.
+license: MIT
+compatibility: Works with OpenSpec artifact workflow.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Clarify
+
+Use this skill before `speckit-specify` when requirements are ambiguous.
+
+## Steps
+1. Review user request and existing docs (`README`, `openspec/`, `.agents/`).
+2. Identify unknowns in scope, data model, UX, non-functional requirements, dependencies, and constraints.
+3. Ask targeted questions (max 5) one-by-one. Prefer short options.
+4. Save answers to `.agents/clarifications.md` with date, decision, impact, and open risks.
+5. Summarize readiness gates for planning.
+
+## Output
+- `.agents/clarifications.md`
+- Bullet list of resolved and unresolved items.
+
+## Guardrails
+- Do not start implementation.
+- If user explicitly skips clarifications, record that risk in the output.

--- a/framework/.windsurf/skills/speckit-plan/SKILL.md
+++ b/framework/.windsurf/skills/speckit-plan/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: speckit-plan
+description: Perform technical planning before coding by producing research, data model, contracts, and quickstart artifacts.
+license: MIT
+compatibility: Works with OpenSpec changes.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Plan
+
+Generates the technical plan and design inputs required before implementation.
+
+## Steps
+1. Read proposal and `.agents/constitution.md`.
+2. Produce `research.md` with decisions, alternatives, security/performance implications.
+3. Produce `data-model.md` for entities, constraints, and lifecycle.
+4. Produce `contracts/` for API/interface definitions.
+5. Produce `quickstart.md` for local validation.
+6. Update `.agents/architecture-decisions.md` with ADR-style records.
+
+## Output
+Inside `openspec/changes/<change-name>/`:
+- `research.md`
+- `data-model.md`
+- `contracts/*`
+- `quickstart.md`
+
+## Guardrails
+- Do not code before plan artifacts exist.
+- Mark unknowns explicitly as `NEEDS CLARIFICATION`.

--- a/framework/.windsurf/skills/speckit-specify/SKILL.md
+++ b/framework/.windsurf/skills/speckit-specify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: speckit-specify
+description: Convert clarified requirements into a change proposal and initialize OpenSpec change naming safely.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Speckit Specify
+
+Transforms intent into a concrete OpenSpec change proposal.
+
+## Steps
+1. Read `.agents/clarifications.md` when present.
+2. Derive a unique kebab-case change name and check collisions in `openspec/changes/`.
+3. Create or update `openspec/changes/<change-name>/proposal.md` with context, objectives, out-of-scope, acceptance criteria, risks.
+4. Confirm user approval before moving to planning.
+
+## Output
+- `openspec/changes/<change-name>/proposal.md`
+- Named change ready for `speckit-plan` and `openspec-continue-change`.
+
+## Guardrails
+- Do not auto-approve the proposal on behalf of the user.
+- Keep proposal aligned with clarified requirements.

--- a/framework/.windsurf/skills/sync-index/SKILL.md
+++ b/framework/.windsurf/skills/sync-index/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: sync-index
+description: Re-run project-index after structural changes and synchronize agent memory artifacts.
+license: MIT
+compatibility: Requires project-index skill.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Sync Index
+
+Keeps project context synchronized after large changes.
+
+## Steps
+1. Detect structural changes (folders, domains, key configs, APIs).
+2. Run `project-index` process and refresh `.agents/project-index.md`.
+3. Update related docs (`.agents/constitution.md`, domain guides, README references).
+4. Summarize context deltas and follow-up actions.
+
+## Output
+- Updated `.agents/project-index.md`
+- Delta summary in `.agents/sync-index-report.md`
+
+## Guardrails
+- Do not overwrite manual notes without preserving prior context.

--- a/framework/.windsurf/skills/test-execution/SKILL.md
+++ b/framework/.windsurf/skills/test-execution/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: test-execution
+description: Execute planned tests, report coverage gaps, and enforce pass/fail gates.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Execution
+
+Runs the test plan and records evidence.
+
+## Steps
+1. Execute commands listed in `.agents/test-plan.md`.
+2. Record pass/fail results in `.agents/test-results.md`.
+3. If failures occur, classify root cause and create follow-up tasks.
+4. Report coverage gaps and add missing cases.
+
+## Output
+- `.agents/test-results.md`
+
+## Guardrails
+- Never claim tests passed without command evidence.
+- Surface flaky tests explicitly.

--- a/framework/.windsurf/skills/test-planning/SKILL.md
+++ b/framework/.windsurf/skills/test-planning/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: test-planning
+description: Design test strategy from requirements and specs before implementation.
+license: MIT
+compatibility: Language-agnostic.
+metadata:
+  author: ac-framework
+  version: "1.0"
+---
+
+# Test Planning
+
+Creates verifiable test coverage tied to requirements.
+
+## Steps
+1. Read proposal, specs, and tasks.
+2. Map acceptance criteria to unit, integration, and end-to-end tests.
+3. Define fixtures, mocks, and negative/error scenarios.
+4. Record command matrix and expected outcomes.
+5. Save plan at `.agents/test-plan.md`.
+
+## Output
+- `.agents/test-plan.md`
+
+## Guardrails
+- Include security and performance regression cases when relevant.
+- Avoid implementation details in test case names.

--- a/framework/.windsurf/workflows/ac.md
+++ b/framework/.windsurf/workflows/ac.md
@@ -1,298 +1,76 @@
- **Fundamental Principle**: *"Quality over speed. Documentation before code. Planning before execution."*
----
+# AC Workflow Orchestrator (OpenSpec + Speckit)
 
-## 🛠️ Available Skills
+**Objetivo**: ejecutar un flujo obligatorio, coherente y auditable para cambios nuevos y existentes.
 
-### Quality and Security Skills
+## Reglas globales
+- Leer al inicio: `.agents/constitution.md` (si no existe, crearlo con principios del proyecto).
+- Mantener artefactos en `.agents/` y `openspec/changes/<change>/`.
+- No avanzar de fase sin completar su **gate**.
+- Consultar `.agents/project-index.md` antes de planificar implementación en proyectos existentes.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `secure-coding-cybersecurity` | Detects and prevents security vulnerabilities (SQLi, XSS, command injection, hardcoded secrets). Follows OWASP Top 10 standards. | Secure code validation |
-| `code-maintainability` | Analyzes code maintainability: duplication, documentation, error handling, naming conventions, SOLID architecture, performance. | Refactoring and standards |
-| `error-handling-patterns` | Error handling patterns in multiple languages: exceptions, Result types, retry, circuit breaker, graceful degradation. | Application resilience |
+## Fase 0 — Preparación
+1. `openspec-onboard` (si equipo nuevo o dudas de metodología).
+2. Crear/validar:
+   - `.agents/constitution.md`
+   - `.agents/clarifications.md`
+   - `.agents/architecture-decisions.md`
 
-### Planning and Design Skills
+**Gate**: constitución y memoria base disponibles.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `brainstorming` | Generates ideas and questions decisions before implementing. Explores requirements, constraints, and success criteria. | Design and architecture |
-| `api-design-principles` | REST and GraphQL design principles: resources, endpoints, pagination, versioning, HATEOAS. | API design |
-| `interface-design` | Interface design (dashboards, admin panels, apps). NOT for landing pages/marketing. | UI design |
+## Fase 1 — Fundamentos y alcance
+1. `speckit-clarify`
+2. `secure-coding-cybersecurity` → `.agents/security-guidelines.md`
+3. `code-maintainability` → `.agents/maintainability-rules.md`
+4. `error-handling-patterns` → `.agents/error-handling.md`
+5. `performance-optimizer` (definir presupuesto inicial)
+6. Opcional según alcance:
+   - `interface-design`
+   - `api-design-principles`
 
-### OpenSpec Skills (The heart of the framework)
+**Gate**: requisitos aclarados + reglas de seguridad/mantenibilidad/errores/rendimiento documentadas.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `openspec-explore` | Exploration mode to investigate problems, map architecture, find integration points before implementing. | Pre-analysis |
-| `openspec-new-change` | Creates a new change with step-by-step workflow (proposal → specs → design → tasks). | Structured start |
-| `openspec-ff-change` | Fast-forward: creates all artifacts at once to start implementation quickly. | Quick start |
-| `openspec-continue-change` | Continues an existing change by creating the next artifact in the sequence. | Continue workflow |
-| `openspec-apply-change` | Implements tasks from a change (applies code according to specs and tasks). | Change execution |
-| `openspec-verify-change` | Verifies that implementation matches artifacts (specs, tasks, design). | Validation |
-| `openspec-archive-change` | Archives a completed change by moving it to `openspec/changes/archive/`. | Change closure |
-| `openspec-onboard` | Guided tutorial to learn OpenSpec with a complete example workflow. | Learning |
-| `openspec-sync-specs` | Synchronizes delta specs to main specs (intelligent merge). | Update specs |
-| `openspec-bulk-archive-change` | Archives multiple completed changes at once. | Bulk cleanup |
+## Fase 2 — Exploración
+1. `openspec-explore`
+2. `project-index` (obligatorio en repos existentes)
 
-### Documentation and Debugging Skills
+**Gate**: `.agents/exploration-report.md` y/o `.agents/project-index.md` actualizado.
 
-| Skill | Description | Primary Use |
-|-------|-------------|---------------|
-| `project-index` | Generates structured project documentation: structure analysis, domains, agent guides. | Indexing and context |
-| `systematic-debugging` | Structured debugging in 4 phases: root cause investigation, pattern analysis, hypothesis, implementation. | Problem resolution |
-| `changelog-generator` | Creates automated changelogs from git commits, translating technical to user language. | Version history |
-| `skill-writer` | Guide to create new skills for Claude Code with correct structure and frontmatter. | Create new skills |
+## Fase 3 — Especificación y planificación
+1. `speckit-specify`
+2. `speckit-plan` (research, data-model, contracts, quickstart)
+3. `brainstorming` (evaluar alternativas y decisión final)
+4. `openspec-new-change` (o continuar uno existente aprobado)
+5. `openspec-continue-change` (design, tasks, specs)
+6. `test-planning`
 
----
+**Gate**:
+- `proposal.md`, `design.md`, `tasks.md`, `specs/*/spec.md`
+- plan técnico creado
+- estrategia de pruebas lista
+- aprobación del usuario para implementar
 
-## 🚀 Workflow: New Project
+## Fase 4 — Implementación
+1. `openspec-apply-change`
+2. `test-execution`
+3. `performance-optimizer` (medición iterativa)
 
-When starting a project **from scratch**, follow this mandatory workflow:
+**Gate**: tareas completadas + pruebas clave pasando + presupuesto de rendimiento dentro de objetivo o con excepción justificada.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: NEW PROJECT                                  │
-└─────────────────────────────────────────────────────────────────────────────────┘
+## Fase 5 — Validación y hardening
+1. `systematic-debugging`
+2. `openspec-verify-change`
+3. `security-scan`
+4. `code-review`
 
-    ┌─────────────────┐
-    │     START       │
-    └────────┬────────┘
-             │
-             ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 1: FOUNDATIONS (Mandatory)            │
-    │                                              │
-    │  1. secure-coding-cybersecurity              │
-    │     └─ Establish security guidelines         │
-    │                                              │
-    │  2. code-maintainability                     │
-    │     └─ Define quality standards              │
-    │                                              │
-    │  3. brainstorming                            │
-    │     └─ Architecture and design decisions     │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 2: SPECIFICATION (Mandatory)          │
-    │                                              │
-    │  4. openspec-new-change                      │
-    │     └─ Create change with proposal           │
-    │                                              │
-    │  5. openspec-continue-change                 │
-    │     └─ Create specs, design, tasks           │
-    │        (or use openspec-ff-change)           │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 3: IMPLEMENTATION                     │
-    │                                              │
-    │  6. openspec-apply-change                    │
-    │     └─ Implement the tasks                   │
-    └────────────────────┬─────────────────────────┘
-                         │
-                         ▼
-    ┌──────────────────────────────────────────────┐
-    │  PHASE 4: VALIDATION AND CLOSURE             │
-    │                                              │
-    │  7. systematic-debugging                     │
-    │     └─ Verify no errors                      │
-    │                                              │
-    │  8. openspec-verify-change                   │
-    │     └─ Validate against specs                │
-    │                                              │
-    │  9. changelog-generator                      │
-    │     └─ Generate in changelogs/by-ai/         │
-    │                                              │
-    │  10. openspec-archive-change                 │
-    │      └─ Archive the change                   │
-    └──────────────────────────────────────────────┘
-```
+**Gate**: verificación completa de specs + reporte de seguridad + revisión sin bloqueantes.
 
-### Phase Descriptions - New Project
+## Fase 6 — Cierre y sincronización
+1. `changelog-generator`
+2. `sync-index` (si hubo cambios estructurales)
+3. `openspec-sync-specs`
+4. `openspec-archive-change`
 
-| Phase | Skill | Description | Expected Output |
-|------|-------|-------------|-----------------|
-| 1 | `secure-coding-cybersecurity` | Establish security guidelines: input validation, sanitization, injection prevention, secrets handling | `.agents/security-guidelines.md` |
-| 2 | `code-maintainability` | Define conventions: naming, folder structure, design patterns, DRY, testing | `.agents/maintainability-rules.md` |
-| 3 | `brainstorming` | Generate architecture ideas, question approach, explore alternatives | `.agents/architecture-decisions.md` |
-| 4 | `openspec-new-change` | Create change with proposal (why, what changes, capabilities) | `openspec/changes/<name>/proposal.md` |
-| 5 | `openspec-continue-change` | Create specs (WHEN/THEN requirements), design (technical decisions), tasks (checklist) | Complete OpenSpec artifacts |
-| 6 | `openspec-apply-change` | Implement code according to specs and tasks | Functional code |
-| 7 | `systematic-debugging` | Structured debugging: investigate root cause, don't guess | Validation report |
-| 8 | `openspec-verify-change` | Verify completeness, correctness, and coherence | Verification report |
-| 9 | `changelog-generator` | Document changes in user language | `changelogs/by-ai/[date]-[feature].md` |
-| 10 | `openspec-archive-change` | Move change to archive with date | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
+**Gate final**: cambio archivado, documentación sincronizada y contexto actualizado.
 
----
-
-## 🔍 Workflow: Existing Project
-
-When working on an **already created** project that does NOT have `.md` documentation files:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                        WORKFLOW: EXISTING PROJECT (NO DOCS)                      │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ⚠️  CHECK: No documentation .md files exist in                         │
-    │       .agents/ or openspec/                                              │
-    │                                                                          │
-    └────────────────────────────────────────────────────┬─────────────────────┘
-                                                         │
-                                                         ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   🔄 STEP 0: project-index                                               │
-    │   Generate complete documentation for existing project                   │
-    │   ├─ Analyze folder structure                                            │
-    │   ├─ Identify domains (UI, Backend, DB, etc.)                            │
-    │   ├─ Create specific sub-skills per domain                               │
-    │   └─ Generate agent-guidance files                                       │
-    │                                                                          │
-    │   Output:                                                                │
-    │   ├─ .agents/project-index.md                                            │
-    │   ├─ .agents/agent-<domain>.md (in each folder)                          │
-    │   └─ .claude/skills/project-index-<domain>/SKILL.md                      │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Post-Indexing
-
-Once the project is indexed, continue with the [Changes Workflow](#-workflow-changesiterations).
-
----
-
-## 🔄 Workflow: Changes/Iterations
-
-For **each change or new feature** in an already documented project:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────────┐
-│                           WORKFLOW: CHANGES AND ITERATIONS                       │
-└─────────────────────────────────────────────────────────────────────────────────┘
-
-    ┌─────────────────────────┐
-    │   START CHANGE          │
-    └────────┬────────────────┘
-             │
-             ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  1. openspec-explore    │────▶│  2. brainstorming                        │
-    │  (Explore current       │     │  (Based on exploration:                  │
-    │   code and structure)   │     │   - Generate ideas                       │
-    └─────────────────────────┘     │   - Suggest improvements                 │
-                                    │   - Ask key questions to user)           │
-                                    └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  3. openspec-new        │────▶│  4. openspec-continue / ff               │
-    │  (Create specification  │     │  (Create specs, design, tasks)           │
-    │   for change/feature)   │     └─────────────────┬────────────────────────┘
-    └─────────────────────────┘                       │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  5. openspec-apply      │────▶│  6. systematic-debugging                 │
-    │  (Implement changes     │     │  (Verify no errors,                      │
-    │   according to tasks)   │     │   validate patterns)                     │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  7. openspec-verify     │────▶│  8. changelog-generator                  │
-    │  (Verify against        │     │  (Generate change record                 │
-    │   specs and design)     │     │   in changelogs/by-ai/)                  │
-    └─────────────────────────┘     └─────────────────┬────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────┐     ┌──────────────────────────────────────────┐
-    │  9. openspec-archive    │────▶│  10. openspec-sync-specs (optional)      │
-    │  (Archive completed     │     │  (Sync specs to main)                    │
-    │   change)               │     └──────────────────────────────────────────┘
-    └─────────────────────────┘
-                                                      │
-                                                      ▼
-    ┌─────────────────────────────────────────────────────────────────────────┐
-    │                                                                          │
-    │   ✅ CHANGE COMPLETED AND DOCUMENTED                                    │
-    │                                                                          │
-    └─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Phase Descriptions - Changes/Iterations
-
-| Phase | Skill | Description | Required Input | Expected Output |
-|------|-------|-------------|-----------------|-----------------|
-| 1 | `openspec-explore` | Analyze current code state, identify dependencies and modification points | Change request context | Impact report in `.agents/exploration-report.md` |
-| 2 | `brainstorming` | Generate ideas based on exploration, suggest alternatives, ask user questions | Exploration report | `.agents/brainstorming-session.md` with decisions |
-| 3 | `openspec-new-change` | Create change container with initial proposal | Brainstorming decisions | `openspec/changes/<name>/proposal.md` |
-| 4 | `openspec-continue-change` or `openspec-ff-change` | Create specs, design, and tasks | Approved proposal | Complete OpenSpec artifacts |
-| 5 | `openspec-apply-change` | Implement tasks as described | Tasks ready | Modified code following specs |
-| 6 | `systematic-debugging` | Validate no errors, verify applied patterns | Modified code | Validation report in `.agents/debug-report.md` |
-| 7 | `openspec-verify-change` | Verify implementation matches specs and design | Artifacts + code | Verification report |
-| 8 | `changelog-generator` | Document change in history | Implemented feature | `changelogs/by-ai/[YYYY-MM-DD]-[feature].md` |
-| 9 | `openspec-archive-change` | Archive completed change | Change ready | `openspec/changes/archive/YYYY-MM-DD-<name>/` |
-| 10 | `openspec-sync-specs` (optional) | Synchronize delta specs to main specs | Delta specs | Main specs updated |
-
----
-
-## ✅ Validation Checklist
-
-Before considering any task as **completed**, verify:
-
-```
-╔═══════════════════════════════════════════════════════════════════════════════════╗
-║                              MANDATORY CHECKLIST                                   ║
-╠═══════════════════════════════════════════════════════════════════════════════════╣
-║                                                                                    ║
-║  □ Security                                                                        ║
-║    └─ □ secure-coding-cybersecurity executed                                     ║
-║    └─ □ No known vulnerabilities (SQL injection, XSS, etc.)                       ║
-║    └─ □ Inputs validated and sanitized                                            ║
-║    └─ □ Secrets/keys not hardcoded                                                ║
-║    └─ □ No eval() or dynamic code execution with user input                       ║
-║                                                                                    ║
-║  □ Maintainability                                                                 ║
-║    └─ □ code-maintainability executed                                            ║
-║    └─ □ Code follows project conventions                                          ║
-║    └─ □ Functions/classes have single responsibility                              ║
-║    └─ □ Descriptive and semantic names                                            ║
-║    └─ □ No duplicate code (DRY principle)                                         ║
-║    └─ □ Documentation explains "why", not "what"                                  ║
-║                                                                                    ║
-║  □ Error Handling                                                                  ║
-║    └─ □ error-handling-patterns applied                                           ║
-║    └─ □ All errors handled gracefully                                             ║
-║    └─ □ Edge cases covered (null, empty, boundaries)                              ║
-║                                                                                    ║
-║  □ Specification (OpenSpec)                                                        ║
-║    └─ □ Change created with proposal, specs, design, tasks                        ║
-║    └─ □ Implementation matches specification                                      ║
-║    └─ □ All WHEN/THEN scenarios implemented                                       ║
-║    └─ □ Design decisions documented                                               ║
-║                                                                                    ║
-║  □ Implementation                                                                  ║
-║    └─ □ All tasks marked complete [- [x]]                                         ║
-║    └─ □ Code tested and functional                                                ║
-║    └─ □ No console.logs or debug code                                             ║
-║                                                                                    ║
-║  □ Validation                                                                      ║
-║    └─ □ systematic-debugging executed without critical errors                     ║
-║    └─ □ openspec-verify-change passed (or reviewed)                               ║
-║    └─ □ Design patterns correctly applied                                         ║
-║                                                                                    ║
-║  □ Documentation                                                                   ║
-║    └─ □ Project index updated if structure changed                                ║
-║    └─ □ Changelog generated in changelogs/by-ai/                                  ║
-║    └─ □ README updated if necessary                                               ║
-║                                                                                    ║
-║  □ Closure                                                                         ║
-║    └─ □ Change archived with openspec-archive-change                              ║
-║    └─ □ Delta specs synchronized (if applicable)                                  ║
-║                                                                                    ║
-╚═══════════════════════════════════════════════════════════════════════════════════╝
+## Orden recomendado para proyectos existentes
+`project-index` → `speckit-clarify` → `speckit-specify` → `speckit-plan` → flujo OpenSpec normal.

--- a/framework/AGENTS.md
+++ b/framework/AGENTS.md
@@ -296,3 +296,27 @@ Before considering any task as **completed**, verify:
 ║    └─ □ Delta specs synchronized (if applicable)                                  ║
 ║                                                                                    ║
 ╚═══════════════════════════════════════════════════════════════════════════════════╝
+
+---
+
+## 🔄 AC Workflow Upgrade (OpenSpec + Speckit)
+
+Mandatory orchestration for `ac`:
+1. Preparation (`openspec-onboard`, constitution files)
+2. Foundations (`speckit-clarify`, security, maintainability, error handling, performance)
+3. Exploration (`openspec-explore`, `project-index`)
+4. Specification & Plan (`speckit-specify`, `speckit-plan`, `openspec-new-change`, `openspec-continue-change`, `test-planning`)
+5. Implementation (`openspec-apply-change`, `test-execution`)
+6. Validation (`systematic-debugging`, `openspec-verify-change`, `security-scan`, `code-review`)
+7. Closure (`changelog-generator`, `sync-index`, `openspec-sync-specs`, `openspec-archive-change`)
+
+### New skills available
+- `speckit-clarify`
+- `speckit-specify`
+- `speckit-plan`
+- `test-planning`
+- `test-execution`
+- `performance-optimizer`
+- `security-scan`
+- `code-review`
+- `sync-index`

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { initCommand } from './commands/init.js';
 import { updateCommand } from './commands/update.js';
+import { verifyCommand } from './commands/verify.js';
 import { showBanner } from './ui/banner.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -34,6 +35,16 @@ program
   .option('--branch <branch>', 'GitHub branch to pull from (default: main)')
   .action(async (opts) => {
     await updateCommand(opts);
+  });
+
+
+program
+  .command('verify')
+  .description('Verify framework parity across assistant folders')
+  .option('--framework <path>', 'Framework directory path', 'framework')
+  .option('--reference <assistant>', 'Reference assistant folder', '.claude')
+  .action(async (opts) => {
+    await verifyCommand(opts);
   });
 
 program.parse();

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,0 +1,24 @@
+import chalk from 'chalk';
+import { verifyFrameworkParity } from '../services/parity-check.js';
+
+export async function verifyCommand(options = {}) {
+  const frameworkDir = options.framework || 'framework';
+  const reference = options.reference || '.claude';
+
+  const result = await verifyFrameworkParity({ frameworkDir, reference });
+
+  console.log(chalk.hex('#636E72')(`Reference assistant: ${reference}`));
+  console.log(chalk.hex('#636E72')(`Assistants checked: ${result.assistants.length}`));
+
+  if (result.drift.length === 0) {
+    console.log(chalk.green('\n✓ Framework parity check passed. No drift detected.'));
+    return;
+  }
+
+  console.log(chalk.red(`\n✗ Drift detected: ${result.drift.length} issue(s)`));
+  for (const item of result.drift) {
+    console.log(chalk.red(`- [${item.type}] ${item.path}`));
+  }
+
+  process.exitCode = 1;
+}

--- a/src/services/parity-check.js
+++ b/src/services/parity-check.js
@@ -1,0 +1,100 @@
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+const SKILLS_ROOT = 'skills';
+
+const AC_CANDIDATES = [
+  'commands/ac.md',
+  'commands/opsx/ac.md',
+  'prompts/ac.md',
+  'workflows/ac.md',
+  'command/ac.md',
+  'openspec/commands/ac.md',
+];
+
+function sha256(input) {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+async function pathExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getSkillManifest(frameworkDir, assistant) {
+  const skillsPath = join(frameworkDir, assistant, SKILLS_ROOT);
+  const entries = await readdir(skillsPath, { withFileTypes: true });
+
+  const skills = {};
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = join(skillsPath, entry.name, 'SKILL.md');
+    if (!(await pathExists(skillPath))) continue;
+    const content = await readFile(skillPath, 'utf8');
+    skills[entry.name] = sha256(content);
+  }
+
+  return skills;
+}
+
+async function getAcHash(frameworkDir, assistant) {
+  for (const relPath of AC_CANDIDATES) {
+    const full = join(frameworkDir, assistant, relPath);
+    if (await pathExists(full)) {
+      const content = await readFile(full, 'utf8');
+      return { relPath, hash: sha256(content) };
+    }
+  }
+  return null;
+}
+
+export async function verifyFrameworkParity({ frameworkDir = 'framework', reference = '.claude' } = {}) {
+  const entries = await readdir(frameworkDir, { withFileTypes: true });
+  const assistants = entries
+    .filter((e) => e.isDirectory() && e.name.startsWith('.') && e.name !== '.clinerules')
+    .map((e) => e.name)
+    .sort((a, b) => a.localeCompare(b));
+
+  if (!assistants.includes(reference)) {
+    throw new Error(`Reference assistant ${reference} was not found under ${frameworkDir}`);
+  }
+
+  const drift = [];
+  const referenceSkills = await getSkillManifest(frameworkDir, reference);
+  const referenceAc = await getAcHash(frameworkDir, reference);
+
+  for (const assistant of assistants) {
+    const skills = await getSkillManifest(frameworkDir, assistant);
+    const ac = await getAcHash(frameworkDir, assistant);
+
+    const allSkills = new Set([...Object.keys(referenceSkills), ...Object.keys(skills)]);
+    for (const skill of [...allSkills].sort()) {
+      if (!(skill in skills)) {
+        drift.push({ assistant, type: 'missing_skill', path: `${assistant}/skills/${skill}/SKILL.md` });
+        continue;
+      }
+      if (!(skill in referenceSkills)) {
+        drift.push({ assistant, type: 'extra_skill', path: `${assistant}/skills/${skill}/SKILL.md` });
+        continue;
+      }
+      if (skills[skill] !== referenceSkills[skill]) {
+        drift.push({ assistant, type: 'skill_content_mismatch', path: `${assistant}/skills/${skill}/SKILL.md` });
+      }
+    }
+
+    if (referenceAc && ac && referenceAc.hash !== ac.hash) {
+      drift.push({
+        assistant,
+        type: 'ac_content_mismatch',
+        path: `${assistant}/${ac.relPath}`,
+      });
+    }
+  }
+
+  return { assistants, reference, drift };
+}


### PR DESCRIPTION
### Motivation
- Bring Speckit' requirements-clarify/plan/specify phases into the OpenSpec flow so `ac` enforces clarification, technical planning, test design and performance/security gates. 
- Close gaps in the current AC workflow by adding explicit QA, performance and security skills to prevent agents skipping phases or producing unverified code. 
- Ensure the same skills and `ac.md` workflow are mirrored across all assistant folders to avoid drift and inconsistent agent behavior. 
- Provide an automated parity check to detect and prevent divergence between assistant-specific copies of skills and `ac` entrypoints.

### Description
- Added a set of cross-framework skills and templates (`speckit-clarify`, `speckit-specify`, `speckit-plan`, `test-planning`, `test-execution`, `performance-optimizer`, `security-scan`, `code-review`, `sync-index`) as `skills/*/SKILL.md` and replicated them across every assistant folder under `framework/` to guarantee parity. 
- Rewrote and unified the `ac` orchestration into an "AC Workflow Orchestrator (OpenSpec + Speckit)" and replaced/updated `ac.md` variants in all assistant command/prompt/workflow locations so the `ac` flow has explicit phases and gates (preparation, foundations, exploration, specify/plan, implement, validate, close). 
- Implemented a parity verifier (`src/services/parity-check.js`) and CLI command `acfm verify` (`src/commands/verify.js`, `src/cli.js`), which compares skill `SKILL.md` hashes and `ac.md` equivalents against a reference assistant (default `.claude`). 
- Updated architecture and guidance docs (`ARQUITECTURA.md`, `framework/AGENTS.md`, `README.md`) to document the new taxonomy, mandatory artifacts in `.agents/`, and the recommended `acfm verify` usage; applied safe minor fixes to some OpenSpec skill files (naming/CLI token format adjustments). 

### Testing
- Ran the parity check with `node src/cli.js verify` which initially reported drift, then after synchronizing the new skills into every assistant the command returned a successful pass (`✓ Framework parity check passed. No drift detected.`). 
- Executed the repository test runner with `npm test`, which completed successfully (no failing suites). 
- Confirmed `ac.md` parity by hashing all `ac.md` files and verifying a single digest across copies. 
- Verified commits were created including all new/updated files (commit message: "Integrate Speckit workflow and add framework parity verification").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4e8931c4832daffe6e5447f8cb67)